### PR TITLE
fix(quic-tls): harden ECH and ClientHello length parsing

### DIFF
--- a/quic-tls/src/client_hello.rs
+++ b/quic-tls/src/client_hello.rs
@@ -460,6 +460,14 @@ impl Deserialize for TlsClientHello {
       error!("Invalid extensions length: {}", extensions_len);
       return Err(TlsClientHelloError::InvalidExtensionLength);
     }
+    if extensions_len > buf.remaining() {
+      error!(
+        "Extensions length {} exceeds remaining ClientHello body length {}",
+        extensions_len,
+        buf.remaining()
+      );
+      return Err(TlsClientHelloError::InvalidExtensionLength);
+    }
     let mut extensions = Vec::new();
 
     let expected_padding_len = buf.remaining() - extensions_len;
@@ -782,6 +790,64 @@ impl Serialize for ProtocolName {
 mod tests {
   use super::*;
   use crate::serialize::parse;
+
+  fn client_hello_body(extensions_len: u16, extensions: &[u8]) -> Vec<u8> {
+    let mut body = Vec::with_capacity(40 + extensions.len());
+    body.extend_from_slice(&0x0303u16.to_be_bytes());
+    body.extend_from_slice(&[0u8; 32]);
+    body.push(0); // Empty legacy session ID.
+    body.extend_from_slice(&0u16.to_be_bytes()); // Empty cipher suites.
+    body.push(0); // Empty legacy compression methods.
+    body.extend_from_slice(&extensions_len.to_be_bytes());
+    body.extend_from_slice(extensions);
+    body
+  }
+
+  #[test]
+  fn empty_ech_extension_returns_short_input() {
+    let mut extension = &[0xfe, 0x0d, 0x00, 0x00][..];
+
+    let result = TlsClientHelloExtension::deserialize(&mut extension);
+
+    assert!(matches!(
+      result,
+      Err(TlsClientHelloError::SerDeserError(SerDeserError::ShortInput))
+    ));
+  }
+
+  #[test]
+  fn truncated_ech_outer_extension_returns_short_input() {
+    let mut extension = &[0xfe, 0x0d, 0x00, 0x01, 0x00][..];
+
+    let result = TlsClientHelloExtension::deserialize(&mut extension);
+
+    assert!(matches!(
+      result,
+      Err(TlsClientHelloError::SerDeserError(SerDeserError::ShortInput))
+    ));
+  }
+
+  #[test]
+  fn client_hello_with_empty_ech_extension_is_rejected() {
+    let extensions = [
+      0xfe, 0x0d, 0x00, 0x00, // Empty ECH extension.
+      0x12, 0x34, 0x00, 0x00, // Empty unknown extension.
+    ];
+    let body = client_hello_body(extensions.len() as u16, &extensions);
+    let mut input = body.as_slice();
+
+    assert!(probe_tls_client_hello(&mut input).is_none());
+  }
+
+  #[test]
+  fn oversized_extensions_length_is_rejected() {
+    let body = client_hello_body(8, &[]);
+    let mut input = body.as_slice();
+
+    let result = TlsClientHello::deserialize(&mut input);
+
+    assert!(matches!(result, Err(TlsClientHelloError::InvalidExtensionLength)));
+  }
 
   #[test]
   fn test_serdeser() {

--- a/quic-tls/src/ech_config.rs
+++ b/quic-tls/src/ech_config.rs
@@ -577,7 +577,7 @@ mod tests {
 
     let serialized = compose(&ech_config_list).unwrap();
     let buf_base64 = BASE64_STANDARD_NO_PAD.encode(&serialized);
-    println!("ech config list (base64): {}", &buf_base64);
+    println!("ech config list (base64): {}", buf_base64);
 
     let record_bytes = BASE64_STANDARD_NO_PAD.decode(&buf_base64).unwrap();
     println!("ech config list (hex): {:x?}", record_bytes);

--- a/quic-tls/src/ech_extension.rs
+++ b/quic-tls/src/ech_extension.rs
@@ -71,6 +71,10 @@ impl Deserialize for EncryptedClientHello {
   where
     Self: Sized,
   {
+    if buf.remaining() < 1 {
+      error!("Not enough data as EncryptedClientHello");
+      return Err(SerDeserError::ShortInput.into());
+    }
     let ech_client_hello_type = buf.get_u8();
     match ech_client_hello_type {
       0 => {
@@ -219,5 +223,33 @@ impl Serialize for OuterExtensions {
       buf.put_u16(ext);
     }
     Ok(())
+  }
+}
+
+/* ------------------------------------------- */
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn empty_ech_input_returns_short_input() {
+    let mut input = &[][..];
+
+    let result = EncryptedClientHello::deserialize(&mut input);
+
+    assert!(matches!(
+      result,
+      Err(TlsClientHelloError::SerDeserError(SerDeserError::ShortInput))
+    ));
+  }
+
+  #[test]
+  fn ech_inner_type_is_unchanged() {
+    let mut input = &[0x01][..];
+
+    let result = EncryptedClientHello::deserialize(&mut input).unwrap();
+
+    assert_eq!(result, EncryptedClientHello::Inner);
   }
 }


### PR DESCRIPTION
Fixed malformed ECH and TLS ClientHello inputs causing parser panics or inconsistent debug/release behavior.