### PR TITLE
feat: remove ech config panic

### DIFF
--- a/proxy-l4-lib/src/config.rs
+++ b/proxy-l4-lib/src/config.rs
@@ -424,18 +424,19 @@ impl EchProtocolConfig {
       .iter()
       .map(|s| {
         let target_addr = if s.contains(':') {
-          TargetAddr::from_str(s).unwrap_or_else(|_| {
-            panic!("Invalid target address: {s}. It should be in the format of <ip>:<port> or <domain>:<port>")
-          })
+          TargetAddr::from_str(s)
         } else {
-          TargetAddr::from_str(&format!("{s}:{listen_port}")).unwrap_or_else(|_| {
-            panic!("Invalid target address: {s}. It should be in the format of <ip>:<port> or <domain>:<port>")
-          })
-        };
+          TargetAddr::from_str(&format!("{s}:{listen_port}"))
+        }
+        .map_err(|_| {
+          ProxyBuildError::InvalidEchPrivateServerName(format!(
+            "Invalid target address: {s}. It should be in the format of <ip>:<port> or <domain>:<port>"
+          ))
+        })?;
         let domain_or_ip = target_addr.domain_or_ip();
-        (domain_or_ip, target_addr)
+        Ok((domain_or_ip, target_addr))
       })
-      .collect();
+      .collect::<Result<ahash::HashMap<_, _>, ProxyBuildError>>()?;
 
     Ok(Self {
       private_keys,
@@ -448,6 +449,19 @@ impl EchProtocolConfig {
 mod tests {
   use super::*;
   use std::collections::HashMap;
+
+  const TEST_ECH_CONFIG_LIST: &str =
+    "AEX+DQBBAQAgACA3tzLigJHNu8j9gnUIH1gdiQdAfoh0LbG/hYn19dSNDQAIAAEAAQABAAMADnB1YmxpYy5leGFtcGxlAAA";
+  const TEST_ECH_PRIVATE_KEY: &str = "lxBu3rEvZXL5RoCWP8LrXMxx10su+YEyEGdxmpiEnIM";
+
+  fn create_ech_protocol_config(private_server_names: &[&str]) -> Result<EchProtocolConfig, ProxyBuildError> {
+    EchProtocolConfig::try_new(
+      TEST_ECH_CONFIG_LIST,
+      &[TEST_ECH_PRIVATE_KEY.to_string()],
+      &private_server_names.iter().map(|name| name.to_string()).collect::<Vec<_>>(),
+      &8443,
+    )
+  }
 
   #[test]
   fn test_validate_basic_config() {
@@ -680,6 +694,41 @@ mod tests {
       private_server_names: Default::default(),
     };
     assert!(validate_ech_config(&ech_config_empty_names, "test").is_err());
+  }
+
+  #[test]
+  fn test_ech_private_server_name_with_invalid_explicit_port_returns_error() {
+    let error =
+      create_ech_protocol_config(&["private.example:not-a-port"]).expect_err("invalid explicit port must return an error");
+    let message = error.to_string();
+
+    assert!(matches!(error, ProxyBuildError::InvalidEchPrivateServerName(_)));
+    assert!(message.contains("private.example:not-a-port"));
+  }
+
+  #[test]
+  fn test_ech_private_server_name_without_port_returns_error_for_invalid_name() {
+    let error =
+      create_ech_protocol_config(&["invalid private name"]).expect_err("invalid implicit-port name must return an error");
+    let message = error.to_string();
+
+    assert!(matches!(error, ProxyBuildError::InvalidEchPrivateServerName(_)));
+    assert!(message.contains("invalid private name"));
+  }
+
+  #[test]
+  fn test_ech_private_server_names_preserve_explicit_and_default_ports() {
+    let config =
+      create_ech_protocol_config(&["private.example:9443", "127.0.0.1"]).expect("valid private server names must be accepted");
+
+    assert_eq!(
+      config.private_server_names.get("private.example").map(ToString::to_string),
+      Some("private.example:9443".to_string())
+    );
+    assert_eq!(
+      config.private_server_names.get("127.0.0.1").map(ToString::to_string),
+      Some("127.0.0.1:8443".to_string())
+    );
   }
 
   #[cfg(feature = "proxy-protocol")]

--- a/proxy-l4-lib/src/config.rs
+++ b/proxy-l4-lib/src/config.rs
@@ -428,9 +428,9 @@ impl EchProtocolConfig {
         } else {
           TargetAddr::from_str(&format!("{s}:{listen_port}"))
         }
-        .map_err(|_| {
+        .map_err(|error| {
           ProxyBuildError::InvalidEchPrivateServerName(format!(
-            "Invalid target address: {s}. It should be in the format of <ip>:<port> or <domain>:<port>"
+            "Invalid target address {s:?}: {error}. Expected a domain or IPv4 address with an optional port, or [IPv6]:port"
           ))
         })?;
         let domain_or_ip = target_addr.domain_or_ip();
@@ -704,6 +704,8 @@ mod tests {
 
     assert!(matches!(error, ProxyBuildError::InvalidEchPrivateServerName(_)));
     assert!(message.contains("private.example:not-a-port"));
+    assert!(message.contains("Invalid port number"));
+    assert!(message.contains("optional port"));
   }
 
   #[test]
@@ -714,6 +716,8 @@ mod tests {
 
     assert!(matches!(error, ProxyBuildError::InvalidEchPrivateServerName(_)));
     assert!(message.contains("invalid private name"));
+    assert!(message.contains("Invalid domain name"));
+    assert!(message.contains("optional port"));
   }
 
   #[test]

--- a/proxy-l4/src/config/toml.rs
+++ b/proxy-l4/src/config/toml.rs
@@ -400,6 +400,10 @@ fn parse_duration(s: &str) -> Result<Duration, anyhow::Error> {
 mod tests {
   use super::*;
 
+  const TEST_ECH_CONFIG_LIST: &str =
+    "AEX+DQBBAQAgACA3tzLigJHNu8j9gnUIH1gdiQdAfoh0LbG/hYn19dSNDQAIAAEAAQABAAMADnB1YmxpYy5leGFtcGxlAAA";
+  const TEST_ECH_PRIVATE_KEY: &str = "lxBu3rEvZXL5RoCWP8LrXMxx10su+YEyEGdxmpiEnIM";
+
   fn parse_config_toml(toml_str: &str) -> ConfigToml {
     toml::from_str::<ConfigToml>(toml_str).expect("failed to parse ConfigToml")
   }
@@ -440,6 +444,30 @@ tcp_target = ["127.0.0.1:80"]
     let config_toml = parse_config_toml(toml_str);
     assert_eq!(config_toml.listen_port, Some(8448));
     assert_eq!(config_toml.tcp_target, Some(vec!["127.0.0.1:80".to_string()]));
+  }
+
+  #[test]
+  fn test_invalid_ech_private_server_name_propagates_from_config_conversion() {
+    let toml_str = format!(
+      r#"
+listen_port = 8443
+
+[protocols.tls_main]
+protocol = "tls"
+target = ["127.0.0.1:443"]
+
+[protocols.tls_main.ech]
+ech_config_list = "{TEST_ECH_CONFIG_LIST}"
+private_keys = ["{TEST_ECH_PRIVATE_KEY}"]
+private_server_names = ["invalid private name"]
+"#
+    );
+    let config_toml = parse_config_toml(&toml_str);
+    let error = Config::try_from(config_toml).expect_err("invalid ECH private server name must propagate");
+    let message = error.to_string();
+
+    assert!(message.contains("Invalid ECH private server name"));
+    assert!(message.contains("invalid private name"));
   }
 
   #[cfg(feature = "proxy-protocol")]


### PR DESCRIPTION
Return errors for invalid ECH private server names instead of panicking.