### PR TITLE
fix: enforce process-wide connection admission

### DIFF
--- a/proxy-l4-lib/src/constants.rs
+++ b/proxy-l4-lib/src/constants.rs
@@ -14,6 +14,9 @@ pub const TCP_BACKLOG: u32 = 1024;
 /// TCP timeout to read first few bytes in milliseconds
 pub const TCP_PROTOCOL_DETECTION_TIMEOUT_MSEC: u64 = 100;
 
+/// Maximum time to establish a TCP connection to a backend.
+pub const TCP_BACKEND_CONNECT_TIMEOUT_MSEC: u64 = 10_000;
+
 /// TCP buffer size for protocol detection
 /// The maximum size of the TLS record is 64KB = 2^14 bytes.
 /// But considering the hybrid post-quantum key exchange (key_share extension is > 1KB in X25519MLKEM768),

--- a/proxy-l4-lib/src/count.rs
+++ b/proxy-l4-lib/src/count.rs
@@ -15,21 +15,32 @@ impl ConnectionCount {
     self.0.load(Ordering::Relaxed)
   }
 
-  pub(crate) fn increment(&self) -> usize {
-    self.0.fetch_add(1, Ordering::Relaxed)
+  /// Atomically acquire one connection slot below `max`.
+  ///
+  /// A maximum of zero rejects every acquisition. The returned permit releases
+  /// the slot when dropped and must remain owned for the admitted resource's
+  /// complete lifetime.
+  pub(crate) fn try_acquire(&self, max: usize) -> Option<ConnectionPermit> {
+    self
+      .0
+      .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        (current < max).then(|| current + 1)
+      })
+      .ok()
+      .map(|_| ConnectionPermit { owner: self.clone() })
   }
+}
 
-  pub(crate) fn decrement(&self) -> usize {
-    let mut count;
-    while {
-      count = self.0.load(Ordering::Relaxed);
-      count > 0
-        && self
-          .0
-          .compare_exchange(count, count - 1, Ordering::Relaxed, Ordering::Relaxed)
-          != Ok(count)
-    } {}
-    count
+#[derive(Debug)]
+/// Non-cloneable ownership token for one admitted connection.
+pub(crate) struct ConnectionPermit {
+  owner: ConnectionCount,
+}
+
+impl Drop for ConnectionPermit {
+  fn drop(&mut self) {
+    let previous = self.owner.0.fetch_sub(1, Ordering::Relaxed);
+    debug_assert!(previous > 0, "connection permit released an empty counter");
   }
 }
 
@@ -64,34 +75,126 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::{
+    sync::{
+      Arc, Barrier,
+      atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+  };
 
   #[test]
-  fn test_connection_count_basic() {
+  fn test_connection_count_exact_boundary_and_release() {
     let count = ConnectionCount::default();
 
     assert_eq!(count.current(), 0);
 
-    count.increment();
+    let first = count.try_acquire(2).unwrap();
     assert_eq!(count.current(), 1);
 
-    count.increment();
+    let second = count.try_acquire(2).unwrap();
+    assert_eq!(count.current(), 2);
+    assert!(count.try_acquire(2).is_none());
     assert_eq!(count.current(), 2);
 
-    count.decrement();
+    drop(first);
     assert_eq!(count.current(), 1);
+
+    let replacement = count.try_acquire(2).unwrap();
+    assert_eq!(count.current(), 2);
+
+    drop((second, replacement));
+    assert_eq!(count.current(), 0);
   }
 
   #[test]
-  fn test_connection_count_multiple_operations() {
+  fn test_connection_count_zero_rejects_without_mutation() {
     let count = ConnectionCount::default();
+    assert!(count.try_acquire(0).is_none());
+    assert_eq!(count.current(), 0);
+  }
 
-    // Simulate multiple connections over time
-    for _ in 0..5 {
-      count.increment();
-      count.decrement();
+  #[test]
+  fn test_connection_count_scope_drop_releases() {
+    let count = ConnectionCount::default();
+    {
+      let _permit = count.try_acquire(1).unwrap();
+      assert_eq!(count.current(), 1);
+    }
+    assert_eq!(count.current(), 0);
+  }
+
+  #[test]
+  fn test_connection_count_threaded_contention_never_exceeds_max() {
+    const THREADS: usize = 64;
+    const MAX: usize = 8;
+
+    let count = ConnectionCount::default();
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let live = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    let handles = (0..THREADS)
+      .map(|_| {
+        let count = count.clone();
+        let barrier = barrier.clone();
+        let live = live.clone();
+        let peak = peak.clone();
+        thread::spawn(move || {
+          barrier.wait();
+          if let Some(permit) = count.try_acquire(MAX) {
+            let current = live.fetch_add(1, Ordering::Relaxed) + 1;
+            peak.fetch_max(current, Ordering::Relaxed);
+            for _ in 0..32 {
+              thread::yield_now();
+            }
+            live.fetch_sub(1, Ordering::Relaxed);
+            drop(permit);
+          }
+        })
+      })
+      .collect::<Vec<_>>();
+
+    for handle in handles {
+      handle.join().unwrap();
     }
 
+    assert!(peak.load(Ordering::Relaxed) <= MAX);
+    assert_eq!(live.load(Ordering::Relaxed), 0);
     assert_eq!(count.current(), 0);
+  }
+
+  #[test]
+  fn test_connection_count_shared_generation_limits() {
+    let old_generation = ConnectionCount::default();
+    let new_generation = old_generation.clone();
+    let mut old_permits = (0..4).map(|_| old_generation.try_acquire(4).unwrap()).collect::<Vec<_>>();
+
+    assert!(new_generation.try_acquire(2).is_none());
+    drop(old_permits.drain(0..3).collect::<Vec<_>>());
+    assert_eq!(new_generation.current(), 1);
+
+    let new_permit = new_generation.try_acquire(2).unwrap();
+    assert!(new_generation.try_acquire(2).is_none());
+    drop(new_permit);
+    assert_eq!(new_generation.current(), 1);
+    drop(old_permits);
+    assert_eq!(new_generation.current(), 0);
+  }
+
+  #[test]
+  fn test_connection_count_independent_owners_do_not_interact() {
+    let tcp = ConnectionCount::default();
+    let udp = ConnectionCount::default();
+
+    let tcp_permit = tcp.try_acquire(1).unwrap();
+    let udp_permit = udp.try_acquire(1).unwrap();
+    assert!(tcp.try_acquire(1).is_none());
+    assert!(udp.try_acquire(1).is_none());
+
+    drop((tcp_permit, udp_permit));
+    assert_eq!(tcp.current(), 0);
+    assert_eq!(udp.current(), 0);
   }
 
   #[test]

--- a/proxy-l4-lib/src/lib.rs
+++ b/proxy-l4-lib/src/lib.rs
@@ -23,7 +23,10 @@ use target::DnsCache;
 
 pub use config::{Config, EchProtocolConfig, ProtocolConfig};
 pub use constants::{DEFAULT_LISTEN_ADDRESS_V4, DEFAULT_LISTEN_ADDRESS_V6, log_event_names};
-pub use count::{ConnectionCount as TcpConnectionCount, ConnectionCountSum as UdpConnectionCount};
+// TODO: Remove this compatibility alias in the next breaking release.
+#[deprecated(note = "use `AdmissionCount` instead; `TcpConnectionCount` will be removed in a future breaking release")]
+pub use count::ConnectionCount as TcpConnectionCount;
+pub use count::{ConnectionCount as AdmissionCount, ConnectionCountSum as UdpConnectionCount};
 pub use destination::LoadBalance;
 pub use error::{ProxyBuildError, ProxyError};
 pub use proto::ProtocolType;

--- a/proxy-l4-lib/src/tcp_proxy.rs
+++ b/proxy-l4-lib/src/tcp_proxy.rs
@@ -7,8 +7,8 @@ use crate::proxy_protocol::InboundProxyProtocolConfig;
 use crate::{
   access_log::{AccessLogProtocolType, access_log_start},
   config::EchProtocolConfig,
-  constants::{TCP_PROTOCOL_DETECTION_BUFFER_SIZE, TCP_PROTOCOL_DETECTION_TIMEOUT_MSEC},
-  count::ConnectionCount,
+  constants::{TCP_BACKEND_CONNECT_TIMEOUT_MSEC, TCP_PROTOCOL_DETECTION_BUFFER_SIZE, TCP_PROTOCOL_DETECTION_TIMEOUT_MSEC},
+  count::{ConnectionCount, ConnectionPermit},
   destination::{LoadBalance, TargetDestination, TlsDestinationItem},
   error::{ProxyBuildError, ProxyError},
   probe::{ProbeResult, TcpProbedProtocol},
@@ -19,7 +19,7 @@ use crate::{
 };
 use bytes::BytesMut;
 use quic_tls::{TlsAlertBuffer, TlsClientHelloBuffer};
-use std::{net::SocketAddr, sync::Arc};
+use std::{future::Future, net::SocketAddr, sync::Arc};
 use tokio::{
   io::{AsyncWriteExt, copy_bidirectional},
   net::TcpStream,
@@ -339,12 +339,10 @@ impl TcpProxy {
           }
           Ok(res) => res,
         };
-        // Connection limit
-        if self.connection_count.current() >= self.max_connections {
-          warn!("TCP connection limit reached: {}", self.max_connections);
+        let Some(connection_permit) = self.connection_count.try_acquire(self.max_connections) else {
+          debug!("TCP connection limit reached: {}", self.max_connections);
           continue;
-        }
-        self.connection_count.increment();
+        };
         debug!(
           "Accepted TCP connection from: {src_addr} (total: {})",
           self.connection_count.current()
@@ -352,13 +350,12 @@ impl TcpProxy {
 
         self.runtime_handle.spawn({
           let dst_mux = Arc::clone(&self.destination_mux);
-          let connection_count = self.connection_count.clone();
           #[cfg(feature = "proxy-protocol")]
           let recv_proxy_protocol_config = self.recv_proxy_protocol_config.clone();
 
           handle_tcp_connection(
             dst_mux,
-            connection_count,
+            connection_permit,
             incoming_stream,
             src_addr,
             #[cfg(feature = "proxy-protocol")]
@@ -402,11 +399,28 @@ fn contextualize_destination_error(error: ProxyError, src_addr: SocketAddr, prob
     .with_protocol_context(&probed_protocol.to_string())
 }
 
+#[derive(Debug)]
+enum TcpBackendConnectError {
+  Io(std::io::Error),
+  Timeout,
+}
+
+async fn connect_tcp_backend_with_timeout<F>(connect: F, duration: Duration) -> Result<TcpStream, TcpBackendConnectError>
+where
+  F: Future<Output = Result<TcpStream, std::io::Error>>,
+{
+  match timeout(duration, connect).await {
+    Ok(Ok(stream)) => Ok(stream),
+    Ok(Err(error)) => Err(TcpBackendConnectError::Io(error)),
+    Err(_) => Err(TcpBackendConnectError::Timeout),
+  }
+}
+
 /* ---------------------------------------------------------- */
 /// Handle TCP connection
 async fn handle_tcp_connection(
   dst_mux: Arc<TcpDestinationMux>,
-  connection_count: ConnectionCount,
+  _connection_permit: ConnectionPermit,
   mut incoming_stream: TcpStream,
   #[cfg(feature = "proxy-protocol")] mut src_addr: SocketAddr,
   #[cfg(not(feature = "proxy-protocol"))] src_addr: SocketAddr,
@@ -430,7 +444,6 @@ async fn handle_tcp_connection(
       }
       Ok(Err(e)) => {
         error!("Failed to parse inbound PROXY header from {src_addr}: {e}");
-        connection_count.decrement();
         return;
       }
       Err(_) => {
@@ -438,7 +451,6 @@ async fn handle_tcp_connection(
           "Timeout ({}ms) reading PROXY header from {src_addr}",
           crate::constants::TCP_PROXY_HEADER_READ_TIMEOUT_MSEC
         );
-        connection_count.decrement();
         return;
       }
     }
@@ -452,7 +464,6 @@ async fn handle_tcp_connection(
   .await
   else {
     error!("Timeout ({TCP_PROTOCOL_DETECTION_TIMEOUT_MSEC}ms) while probing TCP stream from {src_addr}");
-    connection_count.decrement();
     return;
   };
   let probed_protocol = match probe_result {
@@ -460,14 +471,12 @@ async fn handle_tcp_connection(
       Ok(protocol) => protocol,
       Err(unexpected_state) => {
         error!("TCP protocol detector returned unexpected {unexpected_state:?} state for {src_addr}; closing connection");
-        connection_count.decrement();
         return;
       }
     },
     Err(e) => {
       let contextual_error = e.with_source_context(src_addr).with_protocol_context("TCP");
       error!("Failed to detect protocol from {src_addr}: {contextual_error}");
-      connection_count.decrement();
       return;
     }
   };
@@ -479,7 +488,6 @@ async fn handle_tcp_connection(
         .with_source_context(src_addr)
         .with_protocol_context(&probed_protocol.to_string());
       error!("No route for {probed_protocol} from {src_addr}: {contextual_error}");
-      connection_count.decrement();
       return;
     }
   };
@@ -489,7 +497,6 @@ async fn handle_tcp_connection(
     error!("Failed to resolve destination address for {probed_protocol} from {src_addr}: {contextual_error}");
     contextual_error
   }) else {
-    connection_count.decrement();
     return;
   };
 
@@ -503,7 +510,6 @@ async fn handle_tcp_connection(
         if let Err(e) = send_back_tls_alert(&mut incoming_stream, &illegal_parameter_alert).await {
           error!("Failed to send TLS alert: {e}");
         }
-        connection_count.decrement();
         return;
       };
       client_hello_bytes
@@ -514,15 +520,26 @@ async fn handle_tcp_connection(
     }
   };
 
-  let Ok(mut outgoing_stream) = TcpStream::connect(dst_addr).await.map_err(|e| {
-    let contextual_error = ProxyError::IoError(e)
-      .with_connection_context(src_addr, dst_addr)
-      .with_protocol_context(&probed_protocol.to_string());
-    error!("Failed to connect to destination {dst_addr} for {probed_protocol} from {src_addr}: {contextual_error}");
-    contextual_error
-  }) else {
-    connection_count.decrement();
-    return;
+  let mut outgoing_stream = match connect_tcp_backend_with_timeout(
+    TcpStream::connect(dst_addr),
+    Duration::from_millis(TCP_BACKEND_CONNECT_TIMEOUT_MSEC),
+  )
+  .await
+  {
+    Ok(stream) => stream,
+    Err(TcpBackendConnectError::Io(error)) => {
+      let contextual_error = ProxyError::IoError(error)
+        .with_connection_context(src_addr, dst_addr)
+        .with_protocol_context(&probed_protocol.to_string());
+      error!("Failed to connect to destination {dst_addr} for {probed_protocol} from {src_addr}: {contextual_error}");
+      return;
+    }
+    Err(TcpBackendConnectError::Timeout) => {
+      error!(
+        "Timeout ({TCP_BACKEND_CONNECT_TIMEOUT_MSEC}ms) connecting to destination {dst_addr} for {probed_protocol} from {src_addr}"
+      );
+      return;
+    }
   };
 
   #[cfg(feature = "proxy-protocol")]
@@ -537,7 +554,6 @@ async fn handle_tcp_connection(
             .with_connection_context(src_addr, dst_addr)
             .with_protocol_context(&probed_protocol.to_string());
           error!("Failed to write PROXY header to {dst_addr} for {probed_protocol} from {src_addr}: {contextual_error}");
-          connection_count.decrement();
           return;
         }
         debug!("Sent PROXY {pp_version:?} header to {dst_addr} for {probed_protocol} from {src_addr}");
@@ -547,7 +563,6 @@ async fn handle_tcp_connection(
           .with_connection_context(src_addr, dst_addr)
           .with_protocol_context(&probed_protocol.to_string());
         error!("Failed to encode PROXY header for {probed_protocol} from {src_addr}: {contextual_error}");
-        connection_count.decrement();
         return;
       }
     }
@@ -558,7 +573,6 @@ async fn handle_tcp_connection(
       .with_connection_context(src_addr, dst_addr)
       .with_protocol_context(&probed_protocol.to_string());
     error!("Failed to write initial buffer to {dst_addr} for {probed_protocol} from {src_addr}: {contextual_error}");
-    connection_count.decrement();
     return;
   }
   // Here we are establishing a bidirectional connection. Logging the connection.
@@ -581,8 +595,7 @@ async fn handle_tcp_connection(
   }
   // finish log
   tcp_access_log_finish(&src_addr, &dst_addr, &probed_protocol);
-  connection_count.decrement();
-  debug!("TCP proxy connection closed (current: {})", connection_count.current());
+  debug!("TCP proxy connection closed");
 }
 
 /// handle tls, especially ECH
@@ -710,6 +723,26 @@ mod tests {
     assert!(error_msg.contains("resolver unavailable"));
     assert!(!error_msg.contains("unknown"));
     assert!(!error_msg.contains("->"));
+  }
+
+  #[tokio::test]
+  async fn test_backend_connect_timeout_is_distinct_from_io_failure() {
+    let timeout_result = connect_tcp_backend_with_timeout(
+      std::future::pending::<Result<TcpStream, std::io::Error>>(),
+      Duration::from_millis(1),
+    )
+    .await;
+    assert!(matches!(timeout_result, Err(TcpBackendConnectError::Timeout)));
+
+    let io_result = connect_tcp_backend_with_timeout(
+      std::future::ready(Err(std::io::Error::new(
+        std::io::ErrorKind::ConnectionRefused,
+        "connection refused",
+      ))),
+      Duration::from_secs(1),
+    )
+    .await;
+    assert!(matches!(io_result, Err(TcpBackendConnectError::Io(_))));
   }
 
   #[tokio::test]

--- a/proxy-l4-lib/src/udp_conn.rs
+++ b/proxy-l4-lib/src/udp_conn.rs
@@ -1,6 +1,7 @@
 use crate::{
   access_log::{AccessLogProtocolType, access_log_finish, access_log_start},
   constants::{UDP_BUFFER_SIZE, UDP_CHANNEL_CAPACITY},
+  count::ConnectionPermit,
   error::ProxyError,
   proto::UdpProtocolType,
   socket::{DownstreamUdpSocket, bind_udp_socket},
@@ -48,7 +49,6 @@ impl UdpFlowKey {
 }
 
 /* ---------------------------------------------------------- */
-#[derive(Clone)]
 /// Udp connection pool
 pub(crate) struct UdpConnectionPool {
   /// inner hashmap
@@ -83,12 +83,13 @@ impl UdpConnectionPool {
   /// Create and insert a new UdpConnection, and return the
   /// If the source address + port already exists, update the value.
   pub(crate) async fn create_new_connection(
-    &self,
+    self: &Arc<Self>,
     src_addr: &SocketAddr,
     udp_dst: &UdpDestinationInner,
     protocol: &UdpProtocolType,
     udp_socket_to_downstream: Arc<DownstreamUdpSocket>,
     local_ip: IpAddr,
+    connection_permit: ConnectionPermit,
   ) -> Result<UdpConnection, ProxyError> {
     // Connection limit is handled by the caller
 
@@ -100,6 +101,7 @@ impl UdpConnectionPool {
         udp_socket_to_downstream,
         local_ip,
         self.parent_cancel_token.child_token(),
+        connection_permit,
       )
       .await?,
     );
@@ -112,13 +114,13 @@ impl UdpConnectionPool {
       old_conn.inner.cancel_token.cancel(); // cancel the old connection
     }
     // spawn the connection service
-    let self_clone = self.clone();
+    let pool = Arc::clone(self);
     self.runtime_handle.spawn(async move {
       // Here we are establishing a udp connection. Logging info for the connection as an access log.
       udp_access_log_start(&conn);
-      conn.serve(rx, self_clone.runtime_handle.clone()).await;
+      conn.serve(rx, pool.runtime_handle.clone()).await;
       // clean up if the connection service is closed, here the connection service was already closed
-      self_clone.remove(&flow_key);
+      pool.remove_if_same(&flow_key, &conn);
       // finish log
       udp_access_log_finish(&conn);
     });
@@ -128,8 +130,10 @@ impl UdpConnectionPool {
   }
 
   /// Remove the entry by the downstream flow key.
-  fn remove(&self, flow_key: &UdpFlowKey) {
-    self.inner.remove(flow_key);
+  fn remove_if_same(&self, flow_key: &UdpFlowKey, connection: &Arc<UdpConnectionInner>) {
+    self
+      .inner
+      .remove_if(flow_key, |_, current| Arc::ptr_eq(&current.inner, connection));
   }
 
   /// Prune inactive connections
@@ -185,9 +189,12 @@ impl UdpConnection {
   }
 }
 /* ---------------------------------------------------------- */
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 /// Udp connection
 struct UdpConnectionInner {
+  /// Permit for one global UDP connection slot
+  _connection_permit: ConnectionPermit,
+
   /// Udp protocol type
   protocol: UdpProtocolType,
 
@@ -227,6 +234,7 @@ impl UdpConnectionInner {
     udp_socket_to_downstream: Arc<DownstreamUdpSocket>,
     local_ip: IpAddr,
     cancel_token: CancellationToken,
+    connection_permit: ConnectionPermit,
   ) -> Result<Self, ProxyError> {
     let dst_addr = udp_dst.get_destination(src_addr).await?;
     let idle_lifetime = udp_dst.get_connection_idle_lifetime() as u64;
@@ -242,6 +250,7 @@ impl UdpConnectionInner {
     let last_active = Arc::new(AtomicU64::new(get_monotonic_seconds()));
 
     Ok(Self {
+      _connection_permit: connection_permit,
       protocol: protocol.clone(),
       src_addr: *src_addr,
       dst_addr,
@@ -260,22 +269,22 @@ impl UdpConnectionInner {
   }
 
   /// Serve the UdpConnection
-  async fn serve(&self, channel_rx: mpsc::Receiver<Vec<u8>>, runtime_handle: Handle) {
+  async fn serve(self: &Arc<Self>, channel_rx: mpsc::Receiver<Vec<u8>>, runtime_handle: Handle) {
     debug!("UdpConnection from {} to {} started", self.src_addr, self.dst_addr);
     let udp_socket_to_upstream_tx = self.udp_socket_to_upstream.clone();
     let udp_socket_to_upstream_rx = self.udp_socket_to_upstream.clone();
 
     /* ---------------------------------------------------------- */
     let downstream_jh = runtime_handle.clone().spawn({
-      let self_clone = self.clone();
-      async move { self_clone.service_forward_downstream(udp_socket_to_upstream_rx).await }
+      let connection = Arc::clone(self);
+      async move { connection.service_forward_downstream(udp_socket_to_upstream_rx).await }
     });
 
     /* ---------------------------------------------------------- */
     let upstream_jh = runtime_handle.clone().spawn({
-      let self_clone = self.clone();
+      let connection = Arc::clone(self);
       async move {
-        self_clone
+        connection
           .service_forward_upstream(channel_rx, udp_socket_to_upstream_tx)
           .await
       }
@@ -398,7 +407,10 @@ fn udp_access_log_finish(conn: &UdpConnectionInner) {
 /* ---------------------------------------------------------- */
 #[cfg(test)]
 mod tests {
-  use crate::target::{DnsCache, TargetAddr};
+  use crate::{
+    count::ConnectionCount,
+    target::{DnsCache, TargetAddr},
+  };
 
   use super::*;
   use std::str::FromStr;
@@ -420,13 +432,23 @@ mod tests {
     tracing_subscriber::registry().with(stdio_layer).init();
   }
 
+  async fn wait_for_connection_count(count: &ConnectionCount, expected: usize) {
+    tokio::time::timeout(tokio::time::Duration::from_secs(1), async {
+      while count.current() != expected {
+        tokio::task::yield_now().await;
+      }
+    })
+    .await
+    .unwrap();
+  }
+
   #[tokio::test]
   async fn test_udp_connection_pool() {
     init_logger();
     let runtime_handle = tokio::runtime::Handle::current();
 
     let cancel_token = CancellationToken::new();
-    let udp_connection_pool = UdpConnectionPool::new(runtime_handle.clone(), cancel_token.clone());
+    let udp_connection_pool = Arc::new(UdpConnectionPool::new(runtime_handle.clone(), cancel_token.clone()));
 
     let src_addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
     let dns_cache = Arc::new(DnsCache::default());
@@ -441,22 +463,25 @@ mod tests {
     let socket: SocketAddr = "127.0.0.1:55555".parse().unwrap();
     let udp_socket_to_downstream = Arc::new(DownstreamUdpSocket::bind(&socket).unwrap());
     let protocol = UdpProtocolType::Any;
+    let admission_count = ConnectionCount::default();
 
-    let _udp_connection = udp_connection_pool
+    let udp_connection = udp_connection_pool
       .create_new_connection(
         &src_addr,
         &udp_dst,
         &protocol,
         udp_socket_to_downstream,
         IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+        admission_count.try_acquire(1).unwrap(),
       )
       .await
       .unwrap();
+    assert_eq!(admission_count.current(), 1);
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
-
-    udp_connection_pool.prune_inactive_connections();
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    drop(udp_connection);
+    cancel_token.cancel();
+    wait_for_connection_count(&admission_count, 0).await;
+    assert_eq!(admission_count.current(), 0);
   }
 
   #[test]
@@ -512,7 +537,7 @@ mod tests {
     // because not all CI environments have multiple loopback addresses available.
     let runtime_handle = tokio::runtime::Handle::current();
     let cancel_token = CancellationToken::new();
-    let pool = UdpConnectionPool::new(runtime_handle, cancel_token.clone());
+    let pool = Arc::new(UdpConnectionPool::new(runtime_handle, cancel_token.clone()));
 
     let src_addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
     let dns_cache = Arc::new(DnsCache::default());
@@ -531,23 +556,91 @@ mod tests {
     // Both connections share the same downstream socket (bind to loopback).
     let socket_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
     let ds = Arc::new(DownstreamUdpSocket::bind(&socket_addr).unwrap());
+    let admission_count = ConnectionCount::default();
 
-    let _conn_a = pool
-      .create_new_connection(&src_addr, &udp_dst, &UdpProtocolType::Any, ds.clone(), vip_a)
+    let conn_a = pool
+      .create_new_connection(
+        &src_addr,
+        &udp_dst,
+        &UdpProtocolType::Any,
+        ds.clone(),
+        vip_a,
+        admission_count.try_acquire(2).unwrap(),
+      )
       .await
       .unwrap();
-    let _conn_b = pool
-      .create_new_connection(&src_addr, &udp_dst, &UdpProtocolType::Any, ds, vip_b)
+    let conn_b = pool
+      .create_new_connection(
+        &src_addr,
+        &udp_dst,
+        &UdpProtocolType::Any,
+        ds,
+        vip_b,
+        admission_count.try_acquire(2).unwrap(),
+      )
       .await
       .unwrap();
 
     // Both connections must coexist in the pool.
     assert_eq!(pool.local_pool_size(), 2);
+    assert_eq!(admission_count.current(), 2);
     assert!(pool.get(&UdpFlowKey::new(src_addr, vip_a)).is_some());
     assert!(pool.get(&UdpFlowKey::new(src_addr, vip_b)).is_some());
 
+    drop((conn_a, conn_b));
     cancel_token.cancel();
-    // Give spawned tasks time to clean up.
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    wait_for_connection_count(&admission_count, 0).await;
+    assert_eq!(admission_count.current(), 0);
+  }
+
+  #[tokio::test]
+  async fn test_udp_connection_replacement_releases_only_replaced_permit() {
+    let runtime_handle = tokio::runtime::Handle::current();
+    let cancel_token = CancellationToken::new();
+    let pool = Arc::new(UdpConnectionPool::new(runtime_handle, cancel_token.clone()));
+    let src_addr: SocketAddr = "127.0.0.1:12346".parse().unwrap();
+    let local_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let dns_cache = Arc::new(DnsCache::default());
+    let udp_dst = UdpDestinationInner::try_from((
+      ["127.0.0.1:54322".parse::<TargetAddr>().unwrap()].as_slice(),
+      None,
+      &dns_cache,
+      Some(10),
+    ))
+    .unwrap();
+    let downstream = Arc::new(DownstreamUdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap());
+    let admission_count = ConnectionCount::default();
+
+    let replaced = pool
+      .create_new_connection(
+        &src_addr,
+        &udp_dst,
+        &UdpProtocolType::Any,
+        downstream.clone(),
+        local_ip,
+        admission_count.try_acquire(2).unwrap(),
+      )
+      .await
+      .unwrap();
+    let replacement = pool
+      .create_new_connection(
+        &src_addr,
+        &udp_dst,
+        &UdpProtocolType::Any,
+        downstream,
+        local_ip,
+        admission_count.try_acquire(2).unwrap(),
+      )
+      .await
+      .unwrap();
+    assert_eq!(admission_count.current(), 2);
+
+    drop(replaced);
+    wait_for_connection_count(&admission_count, 1).await;
+    assert!(pool.get(&UdpFlowKey::new(src_addr, local_ip)).is_some());
+
+    drop(replacement);
+    cancel_token.cancel();
+    wait_for_connection_count(&admission_count, 0).await;
   }
 }

--- a/proxy-l4-lib/src/udp_proxy.rs
+++ b/proxy-l4-lib/src/udp_proxy.rs
@@ -7,7 +7,7 @@ use crate::{
     UDP_PROBE_MAX_ENTRIES, UDP_PROBE_MAX_ENTRIES_PER_IP, UDP_PROBE_MAX_ENTRIES_PER_IPV6_PREFIX, UDP_PROBE_MAX_PAYLOAD_BYTES,
     UDP_PROBE_OVERLOAD_WARNING_INTERVAL,
   },
-  count::ConnectionCountSum,
+  count::{ConnectionCount, ConnectionCountSum},
   destination::{LoadBalance, TargetDestination, TlsDestinationItem},
   error::{ProxyBuildError, ProxyError},
   probe::{ProbeResult, UdpInitialDatagrams, UdpProbedProtocol},
@@ -259,6 +259,10 @@ pub struct UdpProxy {
   /// Connection counter, set shared counter if #connections of all TCP proxies are needed
   #[builder(default = "ConnectionCountSum::default()")]
   connection_count: ConnectionCountSum<SocketAddr>,
+
+  /// Authoritative connection admission counter shared across listeners and reload generations
+  #[builder(default = "ConnectionCount::default()")]
+  admission_count: ConnectionCount,
 
   /// Max UDP concurrent connections
   #[builder(default = "crate::constants::MAX_UDP_CONCURRENT_CONNECTIONS")]
@@ -989,10 +993,6 @@ fn expire_due(entries: &mut ProbeEntries, expiry_index: &mut ProbeExpiryIndex, n
   expired
 }
 
-fn connection_limit_reached(max_connections: usize, connection_count: usize) -> bool {
-  max_connections > 0 && connection_count >= max_connections
-}
-
 #[derive(Clone)]
 /// Temporary buffer pool of initial UDP datagrams dispatched from each clients.
 /// This is used to buffer the initial datagrams of each client, probe the destination, and then establish a UDP connection.
@@ -1014,6 +1014,9 @@ struct UdpInitialDatagramsBufferPool {
 
   /// Connection counter, set shared counter if #connections of all TCP proxies are needed
   connection_count: ConnectionCountSum<SocketAddr>,
+
+  /// Authoritative connection admission counter
+  admission_count: ConnectionCount,
 
   /// Max UDP concurrent connections
   max_connections: usize,
@@ -1037,6 +1040,7 @@ impl UdpInitialDatagramsBufferPool {
       destination_mux: udp_proxy.destination_mux.clone(),
       runtime_handle: udp_proxy.runtime_handle.clone(),
       connection_count: udp_proxy.connection_count.clone(),
+      admission_count: udp_proxy.admission_count.clone(),
       max_connections: udp_proxy.max_connections,
       budget,
       stats,
@@ -1126,10 +1130,10 @@ impl UdpInitialDatagramsBufferPool {
     };
 
     // UdpConnectionPool deliberately relies on its caller to enforce this cap.
-    if connection_limit_reached(self.max_connections, self.connection_count.current()) {
+    let Some(connection_permit) = self.admission_count.try_acquire(self.max_connections) else {
       self.record_drop(ProbeDropReason::ConnectionLimit);
       return;
-    }
+    };
 
     let connection = match self
       .udp_connection_pool
@@ -1139,6 +1143,7 @@ impl UdpInitialDatagramsBufferPool {
         &probed_protocol.proto_type(),
         self.udp_socket_tx.clone(),
         local_ip,
+        connection_permit,
       )
       .await
     {
@@ -1634,13 +1639,5 @@ mod tests {
       Err(ProbeDropReason::AccountingUnavailable)
     ));
     assert_eq!(budget.snapshot().payload_bytes, 0);
-  }
-
-  #[test]
-  fn test_connection_limit_semantics() {
-    assert!(!connection_limit_reached(0, usize::MAX));
-    assert!(!connection_limit_reached(2, 1));
-    assert!(connection_limit_reached(2, 2));
-    assert!(connection_limit_reached(2, 3));
   }
 }

--- a/proxy-l4/src/main.rs
+++ b/proxy-l4/src/main.rs
@@ -76,12 +76,12 @@ async fn entrypoint(
     .get()
     .ok_or(anyhow::anyhow!("Something wrong in config reloader receiver"))?;
 
-  let tcp_connection_count = TcpConnectionCount::default();
-  let udp_admission_count = TcpConnectionCount::default();
+  let tcp_admission_count = AdmissionCount::default();
+  let udp_admission_count = AdmissionCount::default();
   let mut proxy_service = ProxyService::try_new(
     &config_toml,
     runtime_handle.clone(),
-    tcp_connection_count.clone(),
+    tcp_admission_count.clone(),
     udp_admission_count.clone(),
   )?;
 
@@ -107,7 +107,7 @@ async fn entrypoint(
         match ProxyService::try_new(
           &new_config_toml,
           runtime_handle.clone(),
-          tcp_connection_count.clone(),
+          tcp_admission_count.clone(),
           udp_admission_count.clone(),
         ) {
           Ok(new_proxy_service) => {
@@ -136,8 +136,8 @@ struct ProxyService {
   tcp_backlog: Option<u32>,
   tcp_max_connections: Option<u32>,
   udp_max_connections: Option<u32>,
-  tcp_connection_count: TcpConnectionCount,
-  udp_admission_count: TcpConnectionCount,
+  tcp_admission_count: AdmissionCount,
+  udp_admission_count: AdmissionCount,
   #[cfg(feature = "proxy-protocol")]
   tcp_recv_proxy_protocol: bool,
   #[cfg(feature = "proxy-protocol")]
@@ -151,8 +151,8 @@ impl ProxyService {
   fn try_new(
     config_toml: &ConfigToml,
     runtime_handle: tokio::runtime::Handle,
-    tcp_connection_count: TcpConnectionCount,
-    udp_admission_count: TcpConnectionCount,
+    tcp_admission_count: AdmissionCount,
+    udp_admission_count: AdmissionCount,
   ) -> Result<Self, anyhow::Error> {
     let config = Config::try_from(config_toml.clone())?;
     let (tcp_proxy_mux, udp_proxy_mux) = build_multiplexers(&config)?;
@@ -163,7 +163,7 @@ impl ProxyService {
       tcp_backlog: config.tcp_backlog,
       tcp_max_connections: config.tcp_max_connections,
       udp_max_connections: config.udp_max_connections,
-      tcp_connection_count,
+      tcp_admission_count,
       udp_admission_count,
       #[cfg(feature = "proxy-protocol")]
       tcp_recv_proxy_protocol: config.tcp_recv_proxy_protocol,
@@ -253,7 +253,7 @@ impl ProxyService {
     let mut tcp_proxy_builder = TcpProxyBuilder::default();
     tcp_proxy_builder
       .destination_mux(self.tcp_proxy_mux.clone())
-      .connection_count(self.tcp_connection_count.clone())
+      .connection_count(self.tcp_admission_count.clone())
       .runtime_handle(self.runtime_handle.clone());
     if let Some(tcp_backlog) = self.tcp_backlog {
       tcp_proxy_builder.backlog(tcp_backlog);

--- a/proxy-l4/src/main.rs
+++ b/proxy-l4/src/main.rs
@@ -76,7 +76,14 @@ async fn entrypoint(
     .get()
     .ok_or(anyhow::anyhow!("Something wrong in config reloader receiver"))?;
 
-  let mut proxy_service = ProxyService::try_new(&config_toml, runtime_handle.clone())?;
+  let tcp_connection_count = TcpConnectionCount::default();
+  let udp_admission_count = TcpConnectionCount::default();
+  let mut proxy_service = ProxyService::try_new(
+    &config_toml,
+    runtime_handle.clone(),
+    tcp_connection_count.clone(),
+    udp_admission_count.clone(),
+  )?;
 
   // Continuous monitoring
   loop {
@@ -97,7 +104,12 @@ async fn entrypoint(
           error!("Something wrong in config reloader receiver");
           return Err(anyhow::anyhow!("Something wrong in config reloader receiver"));
         };
-        match ProxyService::try_new(&new_config_toml, runtime_handle.clone()) {
+        match ProxyService::try_new(
+          &new_config_toml,
+          runtime_handle.clone(),
+          tcp_connection_count.clone(),
+          udp_admission_count.clone(),
+        ) {
           Ok(new_proxy_service) => {
             info!("Configuration reloaded");
             proxy_service = new_proxy_service;
@@ -124,6 +136,8 @@ struct ProxyService {
   tcp_backlog: Option<u32>,
   tcp_max_connections: Option<u32>,
   udp_max_connections: Option<u32>,
+  tcp_connection_count: TcpConnectionCount,
+  udp_admission_count: TcpConnectionCount,
   #[cfg(feature = "proxy-protocol")]
   tcp_recv_proxy_protocol: bool,
   #[cfg(feature = "proxy-protocol")]
@@ -134,7 +148,12 @@ struct ProxyService {
 
 impl ProxyService {
   /// Create a new proxy service
-  fn try_new(config_toml: &ConfigToml, runtime_handle: tokio::runtime::Handle) -> Result<Self, anyhow::Error> {
+  fn try_new(
+    config_toml: &ConfigToml,
+    runtime_handle: tokio::runtime::Handle,
+    tcp_connection_count: TcpConnectionCount,
+    udp_admission_count: TcpConnectionCount,
+  ) -> Result<Self, anyhow::Error> {
     let config = Config::try_from(config_toml.clone())?;
     let (tcp_proxy_mux, udp_proxy_mux) = build_multiplexers(&config)?;
 
@@ -144,6 +163,8 @@ impl ProxyService {
       tcp_backlog: config.tcp_backlog,
       tcp_max_connections: config.tcp_max_connections,
       udp_max_connections: config.udp_max_connections,
+      tcp_connection_count,
+      udp_admission_count,
       #[cfg(feature = "proxy-protocol")]
       tcp_recv_proxy_protocol: config.tcp_recv_proxy_protocol,
       #[cfg(feature = "proxy-protocol")]
@@ -161,14 +182,8 @@ impl ProxyService {
 
     /* -------------------------- Tcp -------------------------- */
     if !self.tcp_proxy_mux.is_empty() {
-      // connection count will be shared among all TCP proxies
-      let tcp_conn_count = TcpConnectionCount::default();
       for &listen_on in &self.listen_sockets {
-        let tcp_proxy = self
-          .tcp_builder()
-          .listen_on(listen_on)
-          .connection_count(tcp_conn_count.clone())
-          .build()?;
+        let tcp_proxy = self.tcp_builder().listen_on(listen_on).build()?;
         let tcp_proxy_handle = self.runtime_handle.spawn({
           let cancel_token = cancel_token.child_token();
           async move {
@@ -238,6 +253,7 @@ impl ProxyService {
     let mut tcp_proxy_builder = TcpProxyBuilder::default();
     tcp_proxy_builder
       .destination_mux(self.tcp_proxy_mux.clone())
+      .connection_count(self.tcp_connection_count.clone())
       .runtime_handle(self.runtime_handle.clone());
     if let Some(tcp_backlog) = self.tcp_backlog {
       tcp_proxy_builder.backlog(tcp_backlog);
@@ -255,6 +271,7 @@ impl ProxyService {
     let mut udp_proxy_builder = UdpProxyBuilder::default();
     udp_proxy_builder
       .destination_mux(self.udp_proxy_mux.clone())
+      .admission_count(self.udp_admission_count.clone())
       .runtime_handle(self.runtime_handle.clone());
     if let Some(udp_max_connections) = self.udp_max_connections {
       udp_proxy_builder.max_connections(udp_max_connections as usize);


### PR DESCRIPTION
- add atomic TCP and UDP admission with non-cloneable RAII permits
- share connection counters across listeners and reload generations
- remove manual TCP count releases and bound backend connects to 10 seconds
- tie UDP permits to Arc-owned connection lifetimes
- fix UDP pool cleanup to remove live entries immediately instead of waiting for idle pruning
- preserve replacement entries with identity-checked pool removal
- add concurrency, reload, timeout, and lifecycle regression tests