### PR TITLE
fix: treat zero UDP idle lifetime as unlimited

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ The above configuration works as the following manner.
 > [!IMPORTANT]
 > For the UDP reverse proxy, `rpxy-l4` manages the pseudo connection for each client based on its socket address (IP address + port number) to save the memory usage and preserve the connection state for protocol multiplexing. The pseudo connection is automatically removed after the idle lifetime (default: 30 seconds) since the last packet received from the client. We recommend setting the `udp_idle_lifetime` value in the configuration file to adjust the idle lifetime according to your use case.
 >
+> Setting `udp_idle_lifetime = 0` disables idle expiry. An unlimited pseudo-connection retains its socket, tasks, and global UDP admission slot, and remains in the existing per-datagram pool scan until service completion or error, replacement, cancellation, configuration reload, or shutdown ends it.
+>
 > ```toml
-> # Udp connection idle lifetime in seconds [default: 30]
+> # UDP connection idle lifetime in seconds; 0 disables idle expiry [default: 30]
 > udp_idle_lifetime = 30
 > ```
 
@@ -208,12 +210,12 @@ target = ["192.168.0.6:443"]
 # Load balancing method for QUIC connections [default: none]
 load_balance = "source_socket"
 
-# Idle lifetime for QUIC connections in seconds [default: 30]
+# Idle lifetime for QUIC connections in seconds; 0 disables idle expiry [default: 30]
 idle_lifetime = 30
 ```
 
 > [!NOTE]
-> Since IETF-QUIC is a UDP-based protocol, the `idle_lifetime` field is available for `protocol="quic"` to adjust the idle lifetime of the pseudo connection only valid for QUIC streams.
+> Since IETF-QUIC is a UDP-based protocol, the `idle_lifetime` field is available for `protocol="quic"` to adjust the idle lifetime of the pseudo connection only valid for QUIC streams. Setting it to `0` disables idle expiry with the same resource-retention behavior described for `udp_idle_lifetime`.
 
 Additionally, you can set the `tls_alpn` and `tls_sni` fields for the case where `protocol="tls"` or `protocol="quic"`. These are additional filters for the TLS/QUIC multiplexer to route the stream to the appropriate backend server based on the Application Layer Protocol Negotiation (ALPN) and Server Name Indication (SNI) values. This means that only streams with the specified ALPN and SNI values are forwarded to the target.
 
@@ -252,7 +254,7 @@ idle_lifetime = 30
 ```
 
 > [!NOTE]
-> As well as QUIC, WireGuard is a UDP-based protocol. The `idle_lifetime` field is available for `protocol="wireguard"`. You should adjust the value according to your WireGuard configuration, especially the keep-alive interval.
+> As well as QUIC, WireGuard is a UDP-based protocol. The `idle_lifetime` field is available for `protocol="wireguard"`. Setting it to `0` disables idle expiry with the same resource-retention behavior described for `udp_idle_lifetime`. Otherwise, you should set it longer than the keep-alive interval.
 
 #### 3.3. Passing through only the expected protocols (protocol sanitization)
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -44,6 +44,7 @@ udp_target = [
   "8.8.8.8:53",    # Direct IP
 ]
 udp_load_balance = "source_ip"
+# Set to 0 to disable idle expiry; unlimited flows retain resources until another lifecycle event ends them.
 udp_idle_lifetime = 30
 
 [protocols]
@@ -90,6 +91,7 @@ target = [
   "127.0.0.1:4433",      # Direct IP as fallback
 ]
 load_balance = "source_ip"
+# Set to 0 to disable idle expiry; unlimited flows retain resources until another lifecycle event ends them.
 idle_lifetime = 30
 alpn = ["h3"]
 server_names = ["localhost"]
@@ -102,4 +104,5 @@ target = [
   "192.168.1.2:51820",    # Direct IP as fallback
 ]
 load_balance = "source_ip" # Consistent hashing for domain targets
+# Set to 0 to disable idle expiry; unlimited flows retain resources until another lifecycle event ends them.
 idle_lifetime = 30 # Longer than the keepalive interval

--- a/config.spec.toml
+++ b/config.spec.toml
@@ -71,7 +71,10 @@ udp_target = ["192.168.122.4:53"] # ip:port or domain:port
 # (Optional) Load balancing method for default targets [default: none]
 udp_load_balance = "source_ip"
 
-# (Optional) Udp connection idle lifetime in seconds [default: 30]
+# (Optional) UDP connection idle lifetime in seconds [default: 30]
+# Set to 0 to disable idle expiry. Unlimited pseudo-connections retain their
+# resources and admission slots, and remain in the per-datagram pool scan until
+# service completion/error, replacement, cancellation, reload, or shutdown.
 udp_idle_lifetime = 30
 
 # (Optional) DNS cache minimum TTL in duration format (e.g., "30s", "1m", "1h") [default: 30s]
@@ -184,7 +187,9 @@ target = ["192.168.122.4:443"]
 # Load balancing method for QUIC connections [default: none]
 load_balance = "source_ip"
 
-# (Optional) Idle lifetime for QUIC connections in seconds [default: 30]
+# (Optional) Idle lifetime for UDP-based protocol connections in seconds [default: 30]
+# Set to 0 to disable idle expiry, with the same resource-retention behavior as
+# udp_idle_lifetime.
 idle_lifetime = 30
 
 # server_names = ["example.com", "example.org"]

--- a/proxy-l4-lib/src/config.rs
+++ b/proxy-l4-lib/src/config.rs
@@ -338,7 +338,11 @@ pub struct Config {
   pub udp_target: Option<Vec<TargetAddr>>,
   /// Load balance for UDP
   pub udp_load_balance: Option<LoadBalance>,
-  /// UDP connection lifetime in seconds
+  /// UDP pseudo-connection idle lifetime in seconds.
+  /// `None` uses the default; `Some(0)` disables idle expiry.
+  /// Unlimited connections retain their resources and admission slots and
+  /// remain in the per-datagram pool scan until service completion/error,
+  /// replacement, cancellation, reload, or shutdown ends them.
   pub udp_idle_lifetime: Option<u32>,
   /// DNS cache minimum TTL (default: 30 seconds)
   pub dns_cache_min_ttl: Option<Duration>,
@@ -368,7 +372,11 @@ pub struct ProtocolConfig {
   pub target: Vec<TargetAddr>,
   /// Common for specific protocols
   pub load_balance: Option<LoadBalance>,
-  /// Only UDP based protocol
+  /// Idle lifetime in seconds for UDP-based protocols.
+  /// `None` uses the default; `Some(0)` disables idle expiry.
+  /// Unlimited connections retain their resources and admission slots and
+  /// remain in the per-datagram pool scan until service completion/error,
+  /// replacement, cancellation, reload, or shutdown ends them.
   pub idle_lifetime: Option<u32>,
   /// Only TLS
   pub alpn: Option<Vec<String>>,
@@ -499,6 +507,42 @@ mod tests {
     let mut invalid_config = config.clone();
     invalid_config.udp_max_connections = Some(0);
     assert!(validate_basic_config(&invalid_config).is_err());
+  }
+
+  #[test]
+  fn test_zero_udp_idle_lifetime_is_valid() {
+    let mut global = create_test_udp_config(5353, "127.0.0.1:53");
+    global.udp_idle_lifetime = Some(0);
+
+    let protocol_cases = [
+      ("quic", ProtocolType::Quic, "127.0.0.1:443"),
+      ("wireguard", ProtocolType::Wireguard, "127.0.0.1:51820"),
+    ];
+    let mut cases = vec![("global", global)];
+
+    for (name, protocol, target) in protocol_cases {
+      let mut config = create_test_udp_config(5353, "127.0.0.1:53");
+      config.udp_target = None;
+      config.protocols.insert(
+        name.to_string(),
+        ProtocolConfig {
+          protocol,
+          target: vec![target.parse().unwrap()],
+          load_balance: None,
+          idle_lifetime: Some(0),
+          alpn: None,
+          server_names: None,
+          ech: None,
+          #[cfg(feature = "proxy-protocol")]
+          send_proxy_protocol: SendProxyProtocol::default(),
+        },
+      );
+      cases.push((name, config));
+    }
+
+    for (case, config) in cases {
+      assert!(validate_config(&config).is_ok(), "{case}");
+    }
   }
 
   #[test]

--- a/proxy-l4-lib/src/udp_conn.rs
+++ b/proxy-l4-lib/src/udp_conn.rs
@@ -35,6 +35,10 @@ fn base_any_socket_v6() -> &'static SocketAddr {
 /// DashMap type alias, uses ahash::RandomState as hashbuilder
 type DashMap<K, V> = dashmap::DashMap<K, V, ahash::RandomState>;
 
+fn should_retain_udp_connection(idle_lifetime: u64, last_active: u64, current: u64) -> bool {
+  idle_lifetime == 0 || current.saturating_sub(last_active) < idle_lifetime
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 /// Key for UDP pseudo-connections scoped by downstream source socket and local destination IP.
 pub(crate) struct UdpFlowKey {
@@ -142,12 +146,12 @@ impl UdpConnectionPool {
     self.inner.retain(|_, conn| {
       let last_active = conn.inner.last_active.load(Ordering::Acquire);
       let current = get_monotonic_seconds();
-      let elapsed = current - last_active;
+      let elapsed = current.saturating_sub(last_active);
       debug!(
         "UdpConnection from {} to {} is active for {} seconds",
         conn.inner.src_addr, conn.inner.dst_addr, elapsed
       );
-      if elapsed < conn.inner.idle_lifetime {
+      if should_retain_udp_connection(conn.inner.idle_lifetime, last_active, current) {
         return true;
       }
       debug!("UdpConnection from {} is pruned due to inactivity", conn.inner.src_addr);
@@ -442,6 +446,26 @@ mod tests {
     .unwrap();
   }
 
+  #[test]
+  fn test_should_retain_udp_connection() {
+    let cases = [
+      ("zero lifetime at creation", 0, 100, 100, true),
+      ("zero lifetime after long idle", 0, 100, u64::MAX, true),
+      ("below nonzero boundary", 30, 100, 129, true),
+      ("at nonzero boundary", 30, 100, 130, false),
+      ("above nonzero boundary", 30, 100, 131, false),
+      ("defensive clock regression", 30, 101, 100, true),
+    ];
+
+    for (case, idle_lifetime, last_active, current, expected) in cases {
+      assert_eq!(
+        should_retain_udp_connection(idle_lifetime, last_active, current),
+        expected,
+        "{case}"
+      );
+    }
+  }
+
   #[tokio::test]
   async fn test_udp_connection_pool() {
     init_logger();
@@ -482,6 +506,49 @@ mod tests {
     cancel_token.cancel();
     wait_for_connection_count(&admission_count, 0).await;
     assert_eq!(admission_count.current(), 0);
+  }
+
+  #[tokio::test]
+  async fn test_zero_idle_lifetime_disables_pruning_and_retains_permit() {
+    let runtime_handle = tokio::runtime::Handle::current();
+    let cancel_token = CancellationToken::new();
+    let pool = Arc::new(UdpConnectionPool::new(runtime_handle, cancel_token.clone()));
+    let src_addr: SocketAddr = "127.0.0.1:12347".parse().unwrap();
+    let local_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let dns_cache = Arc::new(DnsCache::default());
+    let udp_dst = UdpDestinationInner::try_from((
+      ["127.0.0.1:54323".parse::<TargetAddr>().unwrap()].as_slice(),
+      None,
+      &dns_cache,
+      Some(0),
+    ))
+    .unwrap();
+    let downstream = Arc::new(DownstreamUdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap());
+    let admission_count = ConnectionCount::default();
+
+    let connection = pool
+      .create_new_connection(
+        &src_addr,
+        &udp_dst,
+        &UdpProtocolType::Any,
+        downstream,
+        local_ip,
+        admission_count.try_acquire(1).unwrap(),
+      )
+      .await
+      .unwrap();
+    assert_eq!(pool.local_pool_size(), 1);
+    assert_eq!(admission_count.current(), 1);
+
+    pool.prune_inactive_connections();
+
+    assert!(pool.get(&UdpFlowKey::new(src_addr, local_ip)).is_some());
+    assert_eq!(pool.local_pool_size(), 1);
+    assert_eq!(admission_count.current(), 1);
+
+    drop(connection);
+    cancel_token.cancel();
+    wait_for_connection_count(&admission_count, 0).await;
   }
 
   #[test]

--- a/proxy-l4/src/config/toml.rs
+++ b/proxy-l4/src/config/toml.rs
@@ -446,6 +446,51 @@ tcp_target = ["127.0.0.1:80"]
   }
 
   #[test]
+  fn test_zero_udp_idle_lifetime_is_accepted_from_toml() {
+    let cases = [
+      (
+        "global",
+        r#"
+listen_port = 8448
+udp_target = ["127.0.0.1:53"]
+udp_idle_lifetime = 0
+"#,
+        None,
+      ),
+      (
+        "quic",
+        r#"
+listen_port = 8448
+
+[protocols.quic]
+protocol = "quic"
+target = ["127.0.0.1:443"]
+idle_lifetime = 0
+"#,
+        Some("quic"),
+      ),
+      (
+        "wireguard",
+        r#"
+listen_port = 8448
+
+[protocols.wireguard]
+protocol = "wireguard"
+target = ["127.0.0.1:51820"]
+idle_lifetime = 0
+"#,
+        Some("wireguard"),
+      ),
+    ];
+
+    for (case, toml_str, protocol_key) in cases {
+      let config = Config::try_from(parse_config_toml(toml_str)).unwrap();
+      let idle_lifetime = protocol_key.map_or(config.udp_idle_lifetime, |key| config.protocols[key].idle_lifetime);
+      assert_eq!(idle_lifetime, Some(0), "{case}");
+    }
+  }
+
+  #[test]
   fn test_invalid_ech_private_server_name_propagates_from_config_conversion() {
     let toml_str = format!(
       r#"


### PR DESCRIPTION
Treat zero UDP idle lifetime as unlimited, with regression tests and documentation updates.